### PR TITLE
Dramatically improve iterators, including adding (optional) rayon support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,15 @@ matrix:
             packages:
               - gcc-multilib
 
+      - rust: stable
+        services: docker
+        env: TARGET=i686-unknown-linux-gnu FEATURES=rayon
+        sudo: required
+        addons:
+          apt:
+            packages:
+              - gcc-multilib
+
       - rust: beta
 
       - rust: 1.23.0
@@ -26,7 +35,16 @@ matrix:
         sudo: required
 
       - rust: stable
+        services: docker
+        env: TARGET=mips64-unknown-linux-gnuabi64 FEATURES=rayon
+        sudo: required
+
+      - rust: stable
         env: COVERAGE=1
+        sudo: required
+
+      - rust: stable
+        env: COVERAGE=1 FEATURES=rayon
         sudo: required
 
 cache: cargo

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ readme = "README.md"
 [build-dependencies]
 rustc_version = "0.2"
 
+[dependencies]
+rayon = { version = "1.1", optional = true }
+
 [dev-dependencies]
 criterion = "0.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ Low-level manipulations of IEEE754 floating-point numbers.
 
 readme = "README.md"
 
+[build-dependencies]
+rustc_version = "0.2"
+
 [dev-dependencies]
 criterion = "0.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ readme = "README.md"
 rustc_version = "0.2"
 
 [dependencies]
-rayon = { version = "1.1", optional = true }
+rayon = { version = "1.0", optional = true }
 
 [dev-dependencies]
 criterion = "0.2"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Low-level manipulations of IEEE754 floating-point numbers.
 
 This library includes:
 
-- unconditional `no_std` support,
+- `no_std` support by default,
 - ulp computation (units in the last place, representing the resolution of a
   float),
 - miscellaneous functions like `nextafter` (`next` and `prev`),
@@ -14,6 +14,8 @@ This library includes:
 - the IEEE-754 `totalOrder` predicate for doing `Ord::cmp`-like
   comparisons on floats,
 - an iterator over every floating point value in a range,
+- a parallel iterator over every floating point value in a range
+  (optional: activate with the `rayon` feature),
 - relative error computation.
 
 [Documentation](http://docs.rs/ieee754),

--- a/benches/iter.rs
+++ b/benches/iter.rs
@@ -30,6 +30,15 @@ fn f32_iter(c: &mut Criterion) {
             assert_eq!(count, i + 1);
         })
     };
+    let positive_find = |b: &mut Bencher, &i: &usize| {
+        let end = f32::recompose(false, 0, i as S);
+        let limit = black_box(1e9);
+        b.iter(|| {
+            assert_eq!(black_box(1_f32).upto(black_box(end))
+                       .map(black_box).find(|a| *a > limit),
+                       None);
+        })
+    };
     let over_zero = |b: &mut Bencher, &i: &usize| {
         let x = f32::recompose(false, -f32::exponent_bias(), (i / 2) as S);
         b.iter(|| {
@@ -47,6 +56,15 @@ fn f32_iter(c: &mut Criterion) {
                 count += 1;
             }
             assert_eq!(count, i + 1);
+        })
+    };
+    let over_zero_find = |b: &mut Bencher, &i: &usize| {
+        let x = f32::recompose(false, -f32::exponent_bias(), (i / 2) as S);
+        let limit = black_box(1e9);
+        b.iter(|| {
+            assert_eq!(black_box(-x).upto(black_box(x))
+                       .map(black_box).find(|a| *a > limit),
+                       None);
         })
     };
     let baseline = |b: &mut Bencher, &i: &usize| {
@@ -67,6 +85,14 @@ fn f32_iter(c: &mut Criterion) {
             assert_eq!(count, i + 1);
         })
     };
+    let baseline_find = |b: &mut Bencher, &i: &usize| {
+        let limit = black_box(1_000_000_000);
+        b.iter(|| {
+            assert_eq!((black_box(0 as B)..=black_box(i as B))
+                       .map(black_box).find(|a| *a > limit),
+                       None);
+        })
+    };
 
     let internal = ParameterizedBenchmark::new("baseline", baseline, SIZES.to_owned())
         .with_function("positive", positive)
@@ -74,9 +100,13 @@ fn f32_iter(c: &mut Criterion) {
     let external = ParameterizedBenchmark::new("baseline", baseline_ext, SIZES.to_owned())
         .with_function("positive", positive_ext)
         .with_function("over_zero", over_zero_ext);
+    let find = ParameterizedBenchmark::new("baseline", baseline_find, SIZES.to_owned())
+        .with_function("positive", positive_find)
+        .with_function("over_zero", over_zero_find);
 
     c.bench("iter_f32_internal", internal);
     c.bench("iter_f32_external", external);
+    c.bench("iter_f32_find", find);
 }
 
 fn f64_iter(c: &mut Criterion) {
@@ -102,6 +132,15 @@ fn f64_iter(c: &mut Criterion) {
             assert_eq!(count, i + 1);
         })
     };
+    let positive_find = |b: &mut Bencher, &i: &usize| {
+        let end = f64::recompose(false, 0, i as S);
+        let limit = black_box(1e9);
+        b.iter(|| {
+            assert_eq!(black_box(1_f64).upto(black_box(end))
+                       .find(|a| *a > limit),
+                       None);
+        })
+    };
     let over_zero = |b: &mut Bencher, &i: &usize| {
         let x = f64::recompose(false, -f64::exponent_bias(), (i / 2) as S);
         b.iter(|| {
@@ -119,6 +158,15 @@ fn f64_iter(c: &mut Criterion) {
                 count += 1;
             }
             assert_eq!(count, i + 1);
+        })
+    };
+    let over_zero_find = |b: &mut Bencher, &i: &usize| {
+        let x = f64::recompose(false, -f64::exponent_bias(), (i / 2) as S);
+        let limit = black_box(1e9);
+        b.iter(|| {
+            assert_eq!(black_box(-x).upto(black_box(x))
+                       .find(|a| *a > limit),
+                       None);
         })
     };
     let baseline = |b: &mut Bencher, &i: &usize| {
@@ -139,6 +187,14 @@ fn f64_iter(c: &mut Criterion) {
             assert_eq!(count, i + 1);
         })
     };
+    let baseline_find = |b: &mut Bencher, &i: &usize| {
+        let limit = black_box(1_000_000_000);
+        b.iter(|| {
+            assert_eq!((black_box(0 as B)..=black_box(i as B))
+                       .find(|a| *a > limit),
+                       None);
+        })
+    };
 
     let internal = ParameterizedBenchmark::new("baseline", baseline, SIZES.to_owned())
         .with_function("positive", positive)
@@ -146,9 +202,13 @@ fn f64_iter(c: &mut Criterion) {
     let external = ParameterizedBenchmark::new("baseline", baseline_ext, SIZES.to_owned())
         .with_function("positive", positive_ext)
         .with_function("over_zero", over_zero_ext);
+    let find = ParameterizedBenchmark::new("baseline", baseline_find, SIZES.to_owned())
+        .with_function("positive", positive_find)
+        .with_function("over_zero", over_zero_find);
 
     c.bench("iter_f64_internal", internal);
     c.bench("iter_f64_external", external);
+    c.bench("iter_f64_find", find);
 }
 
 criterion_group!(benches, f32_iter, f64_iter);

--- a/benches/iter.rs
+++ b/benches/iter.rs
@@ -1,70 +1,154 @@
 #[macro_use] extern crate criterion;
 extern crate ieee754;
 
-use criterion::{Criterion, Fun, black_box};
+use criterion::{Criterion, Bencher, ParameterizedBenchmark, black_box};
 
 use ieee754::Ieee754;
+
+const SIZES: &[usize] = &[10, 100, 1_000, 1_000_000];
 
 fn f32_iter(c: &mut Criterion) {
     type B = <f32 as Ieee754>::Bits;
     type S = <f32 as Ieee754>::Significand;
 
-    let positive = Fun::new("positive", |b, &i: &usize| {
+    let positive = |b: &mut Bencher, &i: &usize| {
         let end = f32::recompose(false, 0, i as S);
         b.iter(|| {
                assert_eq!(black_box(1_f32).upto(black_box(end))
                           .map(black_box).count(),
                           i + 1);
         })
-    });
-    let over_zero = Fun::new("over_zero", |b, &i: &usize| {
+    };
+    let positive_ext = |b: &mut Bencher, &i: &usize| {
+        let end = f32::recompose(false, 0, i as S);
+        b.iter(|| {
+            let mut count = 0;
+            for val in black_box(1_f32).upto(black_box(end)) {
+                black_box(val);
+                count += 1;
+            }
+            assert_eq!(count, i + 1);
+        })
+    };
+    let over_zero = |b: &mut Bencher, &i: &usize| {
         let x = f32::recompose(false, -f32::exponent_bias(), (i / 2) as S);
         b.iter(|| {
                assert_eq!(black_box(-x).upto(black_box(x))
                           .map(black_box).count(),
                           i + 1);
         })
-    });
-    let baseline = Fun::new("baseline", |b, &i: &usize| {
+    };
+    let over_zero_ext = |b: &mut Bencher, &i: &usize| {
+        let x = f32::recompose(false, -f32::exponent_bias(), (i / 2) as S);
+        b.iter(|| {
+            let mut count = 0;
+            for val in black_box(-x).upto(black_box(x)) {
+                black_box(val);
+                count += 1;
+            }
+            assert_eq!(count, i + 1);
+        })
+    };
+    let baseline = |b: &mut Bencher, &i: &usize| {
         b.iter(|| {
             assert_eq!((black_box(0 as B)..=black_box(i as B))
                        .map(black_box).count(),
                        i + 1);
         })
-    });
+    };
+    let baseline_ext = |b: &mut Bencher, &i: &usize| {
+        b.iter(|| {
+            let mut count = 0;
 
-    c.bench_functions("f32_iter", vec![positive, over_zero, baseline], 40);
+            for val in black_box(0 as B)..=black_box(i as B) {
+                black_box(val);
+                count += 1;
+            }
+            assert_eq!(count, i + 1);
+        })
+    };
+
+    let internal = ParameterizedBenchmark::new("baseline", baseline, SIZES.to_owned())
+        .with_function("positive", positive)
+        .with_function("over_zero", over_zero);
+    let external = ParameterizedBenchmark::new("baseline", baseline_ext, SIZES.to_owned())
+        .with_function("positive", positive_ext)
+        .with_function("over_zero", over_zero_ext);
+
+    c.bench("iter_f32_internal", internal);
+    c.bench("iter_f32_external", external);
 }
 
 fn f64_iter(c: &mut Criterion) {
     type B = <f64 as Ieee754>::Bits;
     type S = <f64 as Ieee754>::Significand;
 
-    let positive = Fun::new("positive", |b, &i: &usize| {
+    let positive = |b: &mut Bencher, &i: &usize| {
         let end = f64::recompose(false, 0, i as S);
         b.iter(|| {
                assert_eq!(black_box(1_f64).upto(black_box(end))
                           .map(black_box).count(),
                           i + 1);
         })
-    });
-    let over_zero = Fun::new("over_zero", |b, &i: &usize| {
+    };
+    let positive_ext = |b: &mut Bencher, &i: &usize| {
+        let end = f64::recompose(false, 0, i as S);
+        b.iter(|| {
+            let mut count = 0;
+            for val in black_box(1_f64).upto(black_box(end)) {
+                black_box(val);
+                count += 1;
+            }
+            assert_eq!(count, i + 1);
+        })
+    };
+    let over_zero = |b: &mut Bencher, &i: &usize| {
         let x = f64::recompose(false, -f64::exponent_bias(), (i / 2) as S);
         b.iter(|| {
                assert_eq!(black_box(-x).upto(black_box(x))
                           .map(black_box).count(),
                           i + 1);
         })
-    });
-    let baseline = Fun::new("baseline", |b, &i: &usize| {
+    };
+    let over_zero_ext = |b: &mut Bencher, &i: &usize| {
+        let x = f64::recompose(false, -f64::exponent_bias(), (i / 2) as S);
+        b.iter(|| {
+            let mut count = 0;
+            for val in black_box(-x).upto(black_box(x)) {
+                black_box(val);
+                count += 1;
+            }
+            assert_eq!(count, i + 1);
+        })
+    };
+    let baseline = |b: &mut Bencher, &i: &usize| {
         b.iter(|| {
             assert_eq!((black_box(0 as B)..=black_box(i as B))
                        .map(black_box).count(),
                        i + 1);
         })
-    });
+    };
+    let baseline_ext = |b: &mut Bencher, &i: &usize| {
+        b.iter(|| {
+            let mut count = 0;
 
-    c.bench_functions("f64_iter", vec![positive, over_zero, baseline], 40);
+            for val in black_box(0 as B)..=black_box(i as B) {
+                black_box(val);
+                count += 1;
+            }
+            assert_eq!(count, i + 1);
+        })
+    };
+
+    let internal = ParameterizedBenchmark::new("baseline", baseline, SIZES.to_owned())
+        .with_function("positive", positive)
+        .with_function("over_zero", over_zero);
+    let external = ParameterizedBenchmark::new("baseline", baseline_ext, SIZES.to_owned())
+        .with_function("positive", positive_ext)
+        .with_function("over_zero", over_zero_ext);
+
+    c.bench("iter_f64_internal", internal);
+    c.bench("iter_f64_external", external);
 }
 
 criterion_group!(benches, f32_iter, f64_iter);

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,7 @@
+extern crate rustc_version;
+
+fn main() {
+    if rustc_version::version_meta().unwrap().channel <= rustc_version::Channel::Nightly {
+        println!("cargo:rustc-cfg=nightly");
+    }
+}

--- a/examples/all_ints.rs
+++ b/examples/all_ints.rs
@@ -8,5 +8,5 @@ fn main() {
         - /* -0.0 */ 1
         + /* infinities */ 2;
 
-    println!("count {}", (0..expected as usize).map(criterion::black_box).count());
+    println!("count {}", (0..expected as u32).map(criterion::black_box).count());
 }

--- a/examples/all_ints_par.rs
+++ b/examples/all_ints_par.rs
@@ -1,0 +1,23 @@
+#[cfg(feature = "rayon")]
+extern crate rayon;
+
+// base line comparison for the all example.
+#[cfg(feature = "rayon")]
+fn main() {
+    extern crate criterion;
+    use rayon::prelude::*;
+
+    let expected =
+        /* bits */ (1u64 << 32)
+        - /* NaNs */ (1 << 24)
+        - /* -0.0 */ 1
+        + /* infinities */ 2;
+
+    println!("count {}",
+             (0..expected as u32).into_par_iter().map(criterion::black_box).count());
+}
+
+#[cfg(not(feature = "rayon"))]
+fn main() {
+    println!("all_par requires '--feature rayon'");
+}

--- a/examples/all_par.rs
+++ b/examples/all_par.rs
@@ -1,0 +1,28 @@
+#[cfg(feature = "rayon")]
+extern crate rayon;
+#[cfg(feature = "rayon")]
+extern crate ieee754;
+
+#[cfg(feature = "rayon")]
+fn main() {
+    extern crate criterion;
+    use std::f32 as f;
+
+    use ieee754::Ieee754;
+    use rayon::prelude::*;
+
+    let count = f::NEG_INFINITY.upto(f::INFINITY).into_par_iter().map(criterion::black_box).count();
+    let expected =
+        /* bits */ (1u64 << 32)
+        - /* NaNs */ (1 << 24)
+        - /* -0.0 */ 1
+        + /* infinities */ 2;
+
+    assert_eq!(count, expected as usize);
+    println!("there are {} non-NaN floats", count);
+}
+
+#[cfg(not(feature = "rayon"))]
+fn main() {
+    println!("all_par requires '--features rayon'");
+}

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -445,6 +445,7 @@ macro_rules! mk_impl {
                     }
                 }
 
+                test(0.0, 0.0);
                 test(0.0, 1.0);
                 test(-1.0, 1.0);
                 test(0.0, (0.0 as $f).next().next());

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -263,6 +263,36 @@ macro_rules! mk_impl {
             }
 
             #[test]
+            fn upto_fmt() {
+                fn test(from: $f, to: $f) {
+                    let mut iter = from.upto(to);
+                    assert_eq!(format!("{:?}", iter),
+                               format!("Iter {{ from: {:?}, to: {:?} }}",
+                                       from, to));
+
+                    if from.next() < to.prev() {
+                        let _ = iter.next();
+                        let _ = iter.next_back();
+                        assert_eq!(format!("{:?}", iter),
+                                   format!("Iter {{ from: {:?}, to: {:?} }}",
+                                           from.next(), to.prev()));
+                    }
+
+                    if iter.size_hint().0 < 1_000_000 {
+                        iter.by_ref().for_each(|_| {});
+                        assert_eq!(format!("{:?}", iter),
+                                   "Iter { done: true }");
+                    }
+                }
+
+                test(0.0, 1.0);
+                test(-1.0, 1.0);
+                test(0.0, (0.0 as $f).next().next());
+                test(1e30, (1e30 as $f).next().next().next());
+                test($f::NEG_INFINITY, $f::INFINITY);
+            }
+
+            #[test]
             fn next_prev_order() {
                 let cases = [0.0 as $f, -0.0, 1.0, 1.0001, 1e30, -1.0, -1.0001, -1e30];
                 for &x in &cases {

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -13,6 +13,45 @@ pub fn new_iter<T: Ieee754>(from: T, to: T) -> Iter<T> {
     Iter { from: from.bits(), to: to.bits(), done: false }
 }
 
+fn u64_to_size_hint(x: u64) -> (usize, Option<usize>) {
+    if x <= usize::MAX as u64 {
+        let d = x as usize;
+        (d, Some(d))
+    } else {
+        (usize::MAX, None)
+    }
+}
+
+impl<T: Ieee754> Iter<T> {
+    fn len(&self) -> u64 {
+        let (neg, pos) = self.split_by_sign();
+        neg.len() + pos.len()
+    }
+
+    fn split_by_sign(&self) -> (SingleSignIter<T, Negative>, SingleSignIter<T, Positive>) {
+        let negative = !self.done && self.from.high();
+        let positive = !self.done && !self.to.high();
+
+        let neg_start = self.from;
+        let pos_end = self.to.next();
+
+        let (neg_end, pos_start) = match (negative, positive) {
+            (true, true) => (T::Bits::imin(), T::Bits::zero()),
+            // self is a range with just one sign, so one side is
+            // empty (has start == end)
+            (false, true) => (neg_start, self.from),
+            (true, false) => (self.to.prev(), pos_end),
+            // self is done, so both sides are empty
+            (false, false) => (neg_start, pos_end),
+        };
+
+        (
+            SingleSignIter { from: neg_start, to: neg_end, _sign: Negative },
+            SingleSignIter { from: pos_start, to: pos_end, _sign: Positive },
+        )
+    }
+}
+
 impl<T: Ieee754> Iterator for Iter<T> {
     type Item = T;
     fn next(&mut self) -> Option<T> {
@@ -24,7 +63,7 @@ impl<T: Ieee754> Iterator for Iter<T> {
             // to go down
             true => {
                 let prev = ret.prev();
-                if prev.is_imin() {
+                if prev == T::Bits::imin() {
                     prev.flip_high()
                 } else {
                     prev
@@ -42,32 +81,19 @@ impl<T: Ieee754> Iterator for Iter<T> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        if self.done {
-            return (0, Some(0))
-        }
+        u64_to_size_hint(self.len())
+    }
 
-        fn position<B: Bits>(x: B) -> i64 {
-            let sign = x.high();
-            let abs = x.clear_high().as_u64() as i64;
-            if sign {
-                -abs
-            } else {
-                abs
-            }
-        }
-
-        let from_key = position(self.from);
-        let to_key = position(self.to);
-
-        let distance = (to_key - from_key + 1) as u64;
-        if distance <= usize::MAX as u64 {
-            let d = distance as usize;
-            (d, Some(d))
-        } else {
-            (usize::MAX, None)
-        }
+    // internal iteration optimisations:
+    fn fold<B, F>(self, init: B, mut f: F) -> B
+    where F: FnMut(B, Self::Item) -> B
+    {
+        let (neg, pos) = self.split_by_sign();
+        let next = neg.fold(init, &mut f);
+        pos.fold(next, f)
     }
 }
+
 impl<T: Ieee754> DoubleEndedIterator for Iter<T> {
     fn next_back(&mut self) -> Option<T> {
         if self.done { return None }
@@ -76,7 +102,7 @@ impl<T: Ieee754> DoubleEndedIterator for Iter<T> {
         self.to = if ret.high() {
             ret.next()
         } else {
-            if ret.is_zero() {
+            if ret == T::Bits::zero() {
                 ret.flip_high().next()
             } else {
                 ret.prev()
@@ -100,5 +126,81 @@ impl<T: Ieee754 + fmt::Debug> fmt::Debug for Iter<T> {
                 .field("to", &T::from_bits(self.to));
         }
         dbg.finish()
+    }
+}
+
+// Infrastructure for working with a side of the range that has a
+// single sign, i.e. -x to -0.0 or +0.0 to +y. Loops using these types
+// have no branches other than the loop condition, and compile done to
+// a plain old C-style `for (x = ...; x != y; x++)` (or
+// x--. statically determined).
+
+trait Sign {
+    fn to_pos_inf<B: Bits>(x: B) -> B;
+    fn to_neg_inf<B: Bits>(x: B) -> B;
+
+    fn dist<B: Bits>(from: B, to: B) -> u64;
+
+}
+struct Positive;
+struct Negative;
+
+impl Sign for Positive {
+    fn to_pos_inf<B: Bits>(x: B) -> B { x.next() }
+    fn to_neg_inf<B: Bits>(x: B) -> B { x.prev() }
+
+    fn dist<B: Bits>(from: B, to: B) -> u64 {
+        to.as_u64() - from.as_u64()
+    }
+}
+impl Sign for Negative {
+    fn to_pos_inf<B: Bits>(x: B) -> B { x.prev() }
+    fn to_neg_inf<B: Bits>(x: B) -> B { x.next() }
+
+    fn dist<B: Bits>(from: B, to: B) -> u64 {
+        // sign-magnitude has the order reversed when negative
+        from.as_u64() - to.as_u64()
+    }
+}
+
+struct SingleSignIter<T: Ieee754, S: Sign> {
+    from: T::Bits,
+    to: T::Bits,
+    _sign: S,
+}
+
+impl<T: Ieee754, S: Sign> SingleSignIter<T, S> {
+    fn len(&self) -> u64 {
+        S::dist(self.from, self.to)
+    }
+}
+
+impl<T: Ieee754, S: Sign> Iterator for SingleSignIter<T, S> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        if self.from != self.to {
+            let ret = self.from;
+            self.from = S::to_pos_inf(ret);
+            Some(T::from_bits(ret))
+        } else {
+            None
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        u64_to_size_hint(self.len())
+    }
+
+    fn fold<B, F>(self, mut value: B, mut f: F) -> B
+    where
+        F: FnMut(B, Self::Item) -> B,
+    {
+        let SingleSignIter { mut from, to, .. } = self;
+        while from != to {
+            value = f(value, T::from_bits(from));
+            from = S::to_pos_inf(from);
+        }
+        value
     }
 }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,7 +1,9 @@
 use core::usize;
+use core::fmt;
 use {Bits, Ieee754};
 
 /// An iterator over floating point numbers, created by `Ieee754::upto`.
+#[derive(Clone, Eq, PartialEq)]
 pub struct Iter<T: Ieee754> {
     from: T::Bits,
     to: T::Bits,
@@ -85,5 +87,18 @@ impl<T: Ieee754> DoubleEndedIterator for Iter<T> {
             self.done = true
         }
         return Some(T::from_bits(ret))
+    }
+}
+
+impl<T: Ieee754 + fmt::Debug> fmt::Debug for Iter<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut dbg = f.debug_struct("Iter");
+        if self.done {
+            dbg.field("done", &true);
+        } else {
+            dbg.field("from", &T::from_bits(self.from))
+                .field("to", &T::from_bits(self.to));
+        }
+        dbg.finish()
     }
 }

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -125,7 +125,7 @@ impl<T: Ieee754> PartialEq for Iter<T> {
 }
 impl<T: Ieee754> Eq for Iter<T> {}
 
-impl<T: Ieee754 + fmt::Debug> fmt::Debug for Iter<T> {
+impl<T: Ieee754> fmt::Debug for Iter<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut dbg = f.debug_struct("Iter");
         if self.done() {

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -4,6 +4,9 @@ use core::fmt;
 use core::ops::Try;
 use {Bits, Ieee754};
 
+#[cfg(feature = "rayon")]
+mod rayon;
+
 /// An iterator over floating point numbers, created by `Ieee754::upto`.
 #[derive(Clone, Eq, PartialEq)]
 pub struct Iter<T: Ieee754> {

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -5,10 +5,10 @@ use core::ops::Try;
 use {Bits, Ieee754};
 
 #[cfg(feature = "rayon")]
-mod rayon;
+pub mod rayon;
 
 /// An iterator over floating point numbers, created by `Ieee754::upto`.
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone)]
 pub struct Iter<T: Ieee754> {
     neg: SingleSignIter<T, Negative>,
     pos: SingleSignIter<T, Positive>
@@ -113,6 +113,18 @@ impl<T: Ieee754> DoubleEndedIterator for Iter<T> {
     }
 }
 
+// equal if they would iterate the same elements, even if the precise
+// stored values are different.
+impl<T: Ieee754> PartialEq for Iter<T> {
+    fn eq(&self, other: &Self) -> bool {
+        let mut self_ = self.clone();
+        let mut other_ = other.clone();
+
+        self_.next() == other_.next() && self_.next_back() == other_.next_back()
+    }
+}
+impl<T: Ieee754> Eq for Iter<T> {}
+
 impl<T: Ieee754 + fmt::Debug> fmt::Debug for Iter<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut dbg = f.debug_struct("Iter");
@@ -145,9 +157,9 @@ trait Sign {
     fn dist<B: Bits>(from: B, to: B) -> u64;
 
 }
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq, Debug)]
 struct Positive;
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq, Debug)]
 struct Negative;
 
 impl Sign for Positive {
@@ -168,7 +180,7 @@ impl Sign for Negative {
     }
 }
 
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq, Debug)]
 struct SingleSignIter<T: Ieee754, S: Sign> {
     from: T::Bits,
     to: T::Bits,

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -16,6 +16,7 @@ pub struct Iter<T: Ieee754> {
 /// Create an iterator over the floating point values in [from, to]
 /// (inclusive!)
 pub fn new_iter<T: Ieee754>(from: T, to: T) -> Iter<T> {
+    // this also NaN, e.g. (NaN <= x) == false for all x.
     assert!(from <= to);
 
     let from_bits = from.bits();
@@ -32,8 +33,8 @@ pub fn new_iter<T: Ieee754>(from: T, to: T) -> Iter<T> {
         // empty (has start == end)
         (false, true) => (neg_start, from_bits),
         (true, false) => (to_bits.prev(), pos_end),
-        // self is done, so both sides are empty
-        (false, false) => (neg_start, pos_end),
+        // impossible to have no negative and no positive values
+        (false, false) => unreachable!()
     };
 
     Iter {

--- a/src/iter/rayon.rs
+++ b/src/iter/rayon.rs
@@ -116,11 +116,10 @@ impl<T: Ieee754> UnindexedProducer for IterProducer<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use core::fmt::Debug;
     use core::{f32, f64};
     use std::vec::Vec;
 
-    fn split_test<T: Ieee754 + Debug>(from: T, to: T, mid: T) {
+    fn split_test<T: Ieee754>(from: T, to: T, mid: T) {
         let range = from.upto(to);
         let len = range.len();
         let (left, right) = IterProducer { range: range }.split();
@@ -214,14 +213,14 @@ mod tests {
         split_test(f64::NEG_INFINITY, 1.0, -1.4916681462400413e-154);
         split_test(-1.0, f64::INFINITY, 1.4916681462400413e-154);
     }
-    fn split_fail_test<T: Ieee754 + Debug>(range: Iter<T>) {
+    fn split_fail_test<T: Ieee754>(range: Iter<T>) {
         let (left, right) = IterProducer { range: range.clone() }.split();
         assert_eq!(left.range, range);
         assert!(right.is_none());
     }
     #[test]
     fn test_split_tiny() {
-        fn t<T: Ieee754 + Debug>(x: T) {
+        fn t<T: Ieee754>(x: T) {
             split_fail_test(x.upto(x));
         }
         t(0_f32);
@@ -236,7 +235,7 @@ mod tests {
 
     #[test]
     fn test_split_done() {
-        fn t<T: Ieee754 + Debug>(from: T, to: T) {
+        fn t<T: Ieee754>(from: T, to: T) {
             let mut range = from.upto(to);
             range.by_ref().for_each(|_| {});
             split_fail_test(range)
@@ -250,7 +249,7 @@ mod tests {
 
     #[test]
     fn test_iterate() {
-        fn t<T: Ieee754 + Debug>(from: T, to: T) {
+        fn t<T: Ieee754>(from: T, to: T) {
             // the elements yielded by the parallel iterate should be
             // the same as the non-parallel ones
             let mut parallel = from.upto(to).into_par_iter()

--- a/src/iter/rayon.rs
+++ b/src/iter/rayon.rs
@@ -1,0 +1,1 @@
+extern crate rayon;

--- a/src/iter/rayon.rs
+++ b/src/iter/rayon.rs
@@ -1,1 +1,275 @@
 extern crate rayon;
+
+use {Ieee754, Bits};
+use super::{Iter, SingleSignIter};
+use self::rayon::iter::*;
+use self::rayon::iter::plumbing::*;
+
+/// A parallel iterator over floating point numbers, created by
+/// `into_par_iter` on `Iter`.
+pub struct ParIter<T: Ieee754> {
+    range: Iter<T>
+}
+
+struct IterProducer<T: Ieee754> {
+    range: Iter<T>,
+}
+
+impl<T: Ieee754> IntoParallelIterator for Iter<T> {
+    type Item = T;
+    type Iter = ParIter<T>;
+
+    fn into_par_iter(self) -> Self::Iter {
+        ParIter { range: self }
+    }
+}
+
+impl<T: Ieee754> ParallelIterator for ParIter<T> {
+    type Item = T;
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+    where
+        C: UnindexedConsumer<Self::Item>,
+    {
+        bridge_unindexed(IterProducer { range: self.range }, consumer)
+    }
+
+    fn opt_len(&self) -> Option<usize> {
+        self.range.size_hint().1
+    }
+}
+
+impl<T: Ieee754> IterProducer<T> {
+    // it's convenient to think of the split location separately to
+    // actually doing the split.
+    fn split_at(self, position: u64) -> (Self, Self) {
+        // This splits the range in half by count, not by arithmetic
+        // value.
+        let len = self.range.len();
+        assert!(position <= len);
+
+        let Iter { neg, pos } = self.range;
+
+        let (left, right) = if position < neg.len() {
+            // the split happens within the negative range
+            let mid = neg.from.offset(-(position as i64));
+            (Iter {
+                neg: SingleSignIter { to: mid, .. neg.clone() },
+                // the positive range is empty
+                pos: SingleSignIter { to: pos.from, .. pos.clone() },
+            },
+             Iter {
+                 neg: SingleSignIter { from: mid, .. neg },
+                 pos: pos
+             })
+        } else {
+            // the split happens within the positive range (or at the boundary)
+            let mid = pos.from.offset((position - neg.len()) as i64);
+            (Iter {
+                neg: neg.clone(),
+                pos: SingleSignIter { to: mid, .. pos.clone() },
+            },
+             Iter {
+                 // the negative range is empty
+                 neg: SingleSignIter { from: neg.to, .. neg },
+                 pos: SingleSignIter { from: mid, .. pos }
+             })
+        };
+        // the ranges should be exactly touching, i.e. last of left is
+        // immediately before first of right
+        debug_assert!(left.clone().next_back().map(|x| x.next()) == right.clone().next());
+        debug_assert_eq!(left.len(), position);
+        debug_assert_eq!(right.len(), len - position);
+        (IterProducer { range: left }, IterProducer { range: right })
+    }
+}
+
+impl<T: Ieee754> UnindexedProducer for IterProducer<T> {
+    type Item = T;
+
+    fn split(self) -> (Self, Option<Self>) {
+        if self.range.len() <= 1 {
+            (self, None)
+        } else {
+            // left-bias by rounding up the position (e.g. if self.len()
+            // == 5, we want (3, 2), not (2, 3)).
+            let position = (self.range.len() + 1) / 2;
+            let (left, right) = self.split_at(position);
+            (left, Some(right))
+        }
+    }
+
+    fn fold_with<F>(self, neg_folder: F) -> F
+    where F: Folder<Self::Item> {
+        // consume the two signs separately, to minimise branching
+        let Iter { neg, pos } = self.range;
+
+        let pos_folder = neg_folder.consume_iter(neg);
+        if pos_folder.full() {
+            pos_folder
+        } else {
+            pos_folder.consume_iter(pos)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::fmt::Debug;
+    use core::{f32, f64};
+    use std::vec::Vec;
+
+    fn split_test<T: Ieee754 + Debug>(from: T, to: T, mid: T) {
+        let range = from.upto(to);
+        let len = range.len();
+        let (left, right) = IterProducer { range: range }.split();
+        let right = right.unwrap();
+        assert_eq!(left.range.len(), (len + 1) / 2);
+        assert_eq!(right.range.len(), len / 2);
+        assert_eq!(left.range, from.upto(mid));
+        assert_eq!(right.range, mid.next().upto(to));
+    }
+    #[test]
+    fn test_split_zero() {
+        split_test(0f32, 1.0, 8.131516e-20);
+        split_test(-1f32, 0.0, -8.131516e-20);
+        split_test(0f64, 1.0, 1.118751109680031e-154);
+        split_test(-1f64, 0.0, -1.118751109680031e-154);
+
+        split_test(0f32, f32::INFINITY, 1.5);
+        split_test(f32::NEG_INFINITY, 0.0, -1.5);
+        split_test(0f64, f64::INFINITY, 1.5);
+        split_test(f64::NEG_INFINITY, 0.0, -1.5);
+    }
+    #[test]
+    fn test_split_same_sign() {
+        let x = f32::consts::PI;
+        split_test(x, x.next(), x);
+        split_test(x, x.next().next(), x.next());
+        split_test(x, x.next().next().next(), x.next());
+        split_test(-x.next(), -x, -x.next());
+        split_test(-x.next().next(), -x, -x.next());
+        split_test(-x.next().next().next(), -x, -x.next().next());
+
+        let y = f64::consts::PI;
+        split_test(y, y.next(), y);
+        split_test(y, y.next().next(), y.next());
+        split_test(y, y.next().next().next(), y.next());
+        split_test(-y.next(), -y, -y.next());
+        split_test(-y.next().next(), -y, -y.next());
+        split_test(-y.next().next().next(), -y, -y.next().next());
+
+        // one binade
+        split_test(1f32, 2.0, 1.5);
+        split_test(-2f32, -1.0, -1.5);
+        split_test(1f64, 2.0, 1.5);
+        split_test(-2f64, -1.0, -1.5);
+
+        // cross binade (manually computed by average raw representations)
+        split_test(1e-10_f32, 1e20, 100703.914);
+        split_test(-1e20_f32, -1e-10, -100703.92);
+        split_test(1e-10_f64, 1e20, 100703.91632713746);
+        split_test(-1e20_f64, -1e-10, -100703.91632713747);
+    }
+
+    #[test]
+    fn test_split_awkward_nonsplit() {
+        fn t(x: f32) {
+            split_test(x, x.next(), x);
+        }
+        t(-94618940000.0);
+        t(-34652824.0);
+        t(-34652790.0);
+        t(-23.812748);
+        t(-23.81274);
+        t(-0.0000000000000069391306);
+        t(-0.00000000000000000027740148);
+        t(-0.00000000000000000027740024);
+        t(-0.00000000000000000022259177);
+        t(-0.00000000000000000022259156);
+        t(-0.0000000000000000002195783);
+        t(-0.0000000000000000000000000004100601);
+        t(-0.00000000000000000000000000040458713);
+        t(-0.0000000000000000000000000004045599);
+    }
+
+    #[test]
+    fn test_split_different_signs_equal() {
+        split_test(-1f32, 1.0, 0.0);
+        split_test(-1f64, 1.0, 0.0);
+        split_test(f32::NEG_INFINITY, f32::INFINITY, 0.0);
+        split_test(f64::NEG_INFINITY, f64::INFINITY, 0.0);
+    }
+
+    #[test]
+    fn test_split_different_signs_nonequal() {
+        split_test(-2f32, 1.0, -5.877472e-39);
+        split_test(-1f32, 2.0, 5.877472e-39);
+        split_test(-2f64, 1.0, -1.1125369292536007e-308);
+        split_test(-1f64, 2.0, 1.1125369292536007e-308);
+
+        split_test(f32::NEG_INFINITY, 1.0, -1.0842022e-19);
+        split_test(-1f32, f32::INFINITY, 1.0842022e-19);
+        split_test(f64::NEG_INFINITY, 1.0, -1.4916681462400413e-154);
+        split_test(-1.0, f64::INFINITY, 1.4916681462400413e-154);
+    }
+    fn split_fail_test<T: Ieee754 + Debug>(range: Iter<T>) {
+        let (left, right) = IterProducer { range: range.clone() }.split();
+        assert_eq!(left.range, range);
+        assert!(right.is_none());
+    }
+    #[test]
+    fn test_split_tiny() {
+        fn t<T: Ieee754 + Debug>(x: T) {
+            split_fail_test(x.upto(x));
+        }
+        t(0_f32);
+        t(0_f64);
+
+        t(1_f32);
+        t(1_f64);
+
+        t(-1_f32);
+        t(-1_f64);
+    }
+
+    #[test]
+    fn test_split_done() {
+        fn t<T: Ieee754 + Debug>(from: T, to: T) {
+            let mut range = from.upto(to);
+            range.by_ref().for_each(|_| {});
+            split_fail_test(range)
+        }
+        t(1_f32, 1.0001);
+        t(1_f64, 1.00000000001);
+
+        t(-1.0001_f32, -1.0);
+        t(-1.00000000001_f64, -1.0);
+    }
+
+    #[test]
+    fn test_iterate() {
+        fn t<T: Ieee754 + Debug>(from: T, to: T) {
+            // the elements yielded by the parallel iterate should be
+            // the same as the non-parallel ones
+            let mut parallel = from.upto(to).into_par_iter()
+                .fold_with(
+                    vec![],
+                    |mut v, item| { v.push(item); v }
+                )
+                .reduce_with(|mut x, mut y| { x.append(&mut y); x })
+                .unwrap();
+
+            parallel.sort_by(|x, y| x.partial_cmp(&y).unwrap());
+
+            let serial = from.upto(to).collect::<Vec<_>>();
+            assert_eq!(parallel, serial);
+        }
+
+        t(1_f32, 1.0001);
+        t(1_f64, 1.00000000001);
+        t(-1.0001_f32, -1.0);
+        t(-1.00000000001_f64, -1.0);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,11 +2,19 @@
 //!
 //! # Installation
 //!
-//! Add this to your Cargo.toml
+//! Add this to your Cargo.toml:
 //!
 //! ```toml
 //! [dependencies]
 //! ieee754 = "0.2"
+//! ```
+//!
+//! To enable `rayon` parallel iteration, activate the optional
+//! `rayon` feature:
+//!
+//! ```toml
+//! [dependencies]
+//! ieee754 = { version = "0.2", features = ["rayon"] }
 //! ```
 //!
 //! # Examples
@@ -17,6 +25,25 @@
 //! // there are 840 single-precision floats between 1.0 and 1.0001
 //! // (inclusive).
 //! assert_eq!(1_f32.upto(1.0001).count(), 840);
+//! ```
+//!
+//! If `rayon` is enabled, this can be performed in parallel:
+//!
+//! ```rust
+//! extern crate ieee754;
+//! # #[cfg(feature = "rayon")]
+//! extern crate rayon;
+//!
+//! # #[cfg(feature = "rayon")]
+//! # fn main() {
+//! use ieee754::Ieee754;
+//! use rayon::prelude::*;
+//!
+//! // there are 840 single-precision floats between 1.0 and 1.0001
+//! // (inclusive).
+//! assert_eq!(1_f32.upto(1.0001).into_par_iter().count(), 840);
+//! # }
+//! # #[cfg(not(feature = "rayon"))] fn main() {}
 //! ```
 
 #![no_std]
@@ -29,6 +56,9 @@ mod traits;
 
 pub use traits::{Bits, Ieee754};
 pub use iter::Iter;
+
+#[cfg(feature = "rayon")]
+pub use iter::rayon::ParIter;
 
 #[inline]
 #[doc(hidden)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@
 //! ```
 
 #![no_std]
+#![cfg_attr(nightly, feature(try_trait))]
 #[cfg(test)] #[macro_use] extern crate std;
 
 mod iter;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,4 +1,5 @@
 use core::cmp::Ordering;
+use core::fmt;
 use core::i32;
 use Iter;
 
@@ -91,7 +92,7 @@ impl Bits for u64 {
 }
 
 /// Types that are IEEE754 floating point numbers.
-pub trait Ieee754: Copy + PartialEq + PartialOrd + Send + Sync {
+pub trait Ieee754: Copy + PartialEq + PartialOrd + Send + Sync + fmt::Debug + fmt::Display {
     /// Iterate over each value of `Self` in `[self, lim]`.
     ///
     /// The returned iterator will include subnormal numbers, and will

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -9,8 +9,6 @@ pub trait Bits: Eq + PartialEq + PartialOrd + Ord + Copy + Send + Sync {
     fn zero() -> Self;
     fn imin() -> Self;
     fn high(self) -> bool;
-    fn clear_high(self) -> Self;
-    fn flip_high(self) -> Self;
 
     fn next(self) -> Self;
     fn prev(self) -> Self;
@@ -33,14 +31,6 @@ impl Bits for u32 {
     #[inline]
     fn high(self) -> bool {
         self & (1 << 31) != 0
-    }
-    #[inline]
-    fn clear_high(self) -> Self {
-        self & !(1 << 31)
-    }
-    #[inline]
-    fn flip_high(self) -> Self {
-        self ^ (1 << 31)
     }
 
     #[inline]
@@ -70,14 +60,6 @@ impl Bits for u64 {
     #[inline]
     fn high(self) -> bool {
         self & (1 << 63) != 0
-    }
-    #[inline]
-    fn clear_high(self) -> Self {
-        self & !(1 << 63)
-    }
-    #[inline]
-    fn flip_high(self) -> Self {
-        self ^ (1 << 63)
     }
 
     #[inline]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,8 +1,8 @@
 use core::cmp::Ordering;
-
+use core::i32;
 use Iter;
 
-pub trait Bits: Eq + PartialEq + PartialOrd + Ord + Copy {
+pub trait Bits: Eq + PartialEq + PartialOrd + Ord + Copy + Send + Sync {
     fn as_u64(self) -> u64;
 
     fn zero() -> Self;
@@ -13,6 +13,8 @@ pub trait Bits: Eq + PartialEq + PartialOrd + Ord + Copy {
 
     fn next(self) -> Self;
     fn prev(self) -> Self;
+
+    fn offset(self, offset: i64) -> Self;
 }
 impl Bits for u32 {
     #[inline]
@@ -44,6 +46,12 @@ impl Bits for u32 {
     fn next(self) -> Self { self + 1 }
     #[inline]
     fn prev(self) -> Self { self - 1 }
+
+    #[inline]
+    fn offset(self, offset: i64) -> Self {
+        debug_assert!(i32::MIN as i64 <= offset && offset <= i32::MAX as i64);
+        self.wrapping_add(offset as u32)
+    }
 }
 impl Bits for u64 {
     #[inline]
@@ -75,10 +83,15 @@ impl Bits for u64 {
     fn next(self) -> Self { self + 1 }
     #[inline]
     fn prev(self) -> Self { self - 1 }
+
+    #[inline]
+    fn offset(self, offset: i64) -> Self {
+        self.wrapping_add(offset as u64)
+    }
 }
 
 /// Types that are IEEE754 floating point numbers.
-pub trait Ieee754: Copy + PartialEq + PartialOrd {
+pub trait Ieee754: Copy + PartialEq + PartialOrd + Send + Sync {
     /// Iterate over each value of `Self` in `[self, lim]`.
     ///
     /// The returned iterator will include subnormal numbers, and will

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -4,12 +4,75 @@ use Iter;
 
 pub trait Bits: Eq + PartialEq + PartialOrd + Ord + Copy {
     fn as_u64(self) -> u64;
+
+    fn high(self) -> bool;
+    fn is_zero(self) -> bool;
+    fn is_imin(self) -> bool;
+    fn clear_high(self) -> Self;
+    fn flip_high(self) -> Self;
+
+    fn next(self) -> Self;
+    fn prev(self) -> Self;
 }
 impl Bits for u32 {
+    #[inline]
     fn as_u64(self) -> u64 { self as u64 }
+
+    #[inline]
+    fn high(self) -> bool {
+        self & (1 << 31) != 0
+    }
+    #[inline]
+    fn is_zero(self) -> bool {
+        self == 0
+    }
+    #[inline]
+    fn is_imin(self) -> bool {
+        self == 1 << 31
+    }
+    #[inline]
+    fn clear_high(self) -> Self {
+        self & !(1 << 31)
+    }
+    #[inline]
+    fn flip_high(self) -> Self {
+        self ^ (1 << 31)
+    }
+
+    #[inline]
+    fn next(self) -> Self { self + 1 }
+    #[inline]
+    fn prev(self) -> Self { self - 1 }
 }
 impl Bits for u64 {
+    #[inline]
     fn as_u64(self) -> u64 { self }
+
+    #[inline]
+    fn high(self) -> bool {
+        self & (1 << 63) != 0
+    }
+    #[inline]
+    fn is_zero(self) -> bool {
+        self == 0
+    }
+    #[inline]
+    fn is_imin(self) -> bool {
+        self == 1 << 63
+    }
+    #[inline]
+    fn clear_high(self) -> Self {
+        self & !(1 << 63)
+    }
+    #[inline]
+    fn flip_high(self) -> Self {
+        self ^ (1 << 63)
+    }
+
+    #[inline]
+    fn next(self) -> Self { self + 1 }
+    #[inline]
+    fn prev(self) -> Self { self - 1 }
 }
 
 /// Types that are IEEE754 floating point numbers.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -5,9 +5,9 @@ use Iter;
 pub trait Bits: Eq + PartialEq + PartialOrd + Ord + Copy {
     fn as_u64(self) -> u64;
 
+    fn zero() -> Self;
+    fn imin() -> Self;
     fn high(self) -> bool;
-    fn is_zero(self) -> bool;
-    fn is_imin(self) -> bool;
     fn clear_high(self) -> Self;
     fn flip_high(self) -> Self;
 
@@ -19,16 +19,17 @@ impl Bits for u32 {
     fn as_u64(self) -> u64 { self as u64 }
 
     #[inline]
+    fn zero() -> Self {
+        0
+    }
+    #[inline]
+    fn imin() -> Self {
+        1 << 31
+    }
+
+    #[inline]
     fn high(self) -> bool {
         self & (1 << 31) != 0
-    }
-    #[inline]
-    fn is_zero(self) -> bool {
-        self == 0
-    }
-    #[inline]
-    fn is_imin(self) -> bool {
-        self == 1 << 31
     }
     #[inline]
     fn clear_high(self) -> Self {
@@ -49,16 +50,17 @@ impl Bits for u64 {
     fn as_u64(self) -> u64 { self }
 
     #[inline]
+    fn zero() -> Self {
+        0
+    }
+    #[inline]
+    fn imin() -> Self {
+        1 << 63
+    }
+
+    #[inline]
     fn high(self) -> bool {
         self & (1 << 63) != 0
-    }
-    #[inline]
-    fn is_zero(self) -> bool {
-        self == 0
-    }
-    #[inline]
-    fn is_imin(self) -> bool {
-        self == 1 << 63
     }
     #[inline]
     fn clear_high(self) -> Self {


### PR DESCRIPTION
Speed increases of the included benchmarks and examples, for the different types:

| style                     |           f32 |          f64 |
|---------------------------|--------------:|-------------:|
| internal benchmark (`count`/`fold`) |    2-4&times; | 2.5-5&times; |
| external benchmark (`next`/`for`)   | 1.25-2&times; | 1.4-2&times; |
| `all` example | 4.6&times; | - |
| `all_rev` example | 1.6&times; | - |

Additionally, `Iter` (the return value of `.upto`) now supports parallel iteration with `rayon` via the optional `rayon` feature. (Closes #9.)

The `all` and `all_par` benchmarks are serial and parallel (respectively) benchmarks that count all 4 billion `f32`s (exactly 4,278,190,081)  from -&infin; to +&infin;.

| CPU | `all` (s) | `all_par` (s) | speedup |
|---|--:|--:|--:|
| i7-8750H (6 cores, 12 hyperthreads) | 1.1 | 0.21 | 5.2&times; |
| i9-9880H (8 C, 16 HT)  | 1.0 | 0.16 | 6.3&times; |

It scales well. When restricting the number of threads rayon uses with `RAYON_NUM_THREADS=<count>` on the i9-9880H, the scaling is quite linear up to the core count, and there's minimal overhead:

![ieee754-rayon](https://user-images.githubusercontent.com/1203825/62832993-e1b0c080-bc7a-11e9-92c2-69718483c84d.png)

(I suspect CPU throttling is the major cause of the nonlinearity towards the end and the speed-up being not precisely the core count.)

How does this work?

- manipulating bits (`u32` or `u64`) in the iterator (closes #7)
- storing exclusive ranges internally: `x.upto(y)` is an inclusive range `[x, y]` (yields `y` as its last element) but stores `[x, y.next())` internally
- splitting into two ranges internally (representing the negative region and the positive region) where their `next`s have no branching other than the end condition (e.g. no need to check whether we're crossing zero), and overloading internal iteration functions like `fold` (and `try_fold` on nightly) to work with each separately
