### PR TITLE
Move to try_trait_v2 unstable feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,8 @@
 //! ```
 
 #![no_std]
-#![cfg_attr(nightly, feature(try_trait))]
+//#![cfg_attr(nightly, feature(try_trait_v2))]
+#![feature(try_trait_v2)]
 #[cfg(test)] #[macro_use] extern crate std;
 
 mod iter;


### PR DESCRIPTION
`try_trait` has now been removed (see https://github.com/rust-lang/rust/issues/42327#issuecomment-910526260) and replaced with `try_trait_v2`. Crate fails to compile with the latest nightly (because `Try::Ok` has been replaced with `Try::Output`.

I have switched to the new `try_trait_v2`. Please note that I have taken the liberty of removing `try_fold_result` and `try_rfold_result`, given `try_fold` and `try_rfold` are now stable (even though `Try` still requires `try_trait_v2`). I could re-instate them if you prefer (although I'm not sure whether to prefer wrapping a `Result` with a `Try`, or the other way around).