### PR TITLE
Add constants with info on exp/significand size.

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -22,6 +22,15 @@ macro_rules! mk_impl {
             type Exponent = $expn;
             type RawExponent = $expn_raw;
             type Significand = $signif;
+
+            const SIGNIF_SIZE : u8 = $signif_n;
+            const EXP_SIZE : u8 = $expn_n;
+            const EXP_ZERO_SUBNORMAL : Self::RawExponent = 0;
+            const EXP_INF_NAN : Self::RawExponent = ((1 << $expn_n) - 1) as Self::RawExponent;
+            const EXP_SMALLEST_NORMAL : Self::RawExponent = 1;
+            const EXP_HIGHEST_NORMAL : Self::RawExponent = ((1 << $expn_n) - 2) as Self::RawExponent;
+            const EXP_BIAS : Self::Exponent = (1 << ($expn_n - 1)) - 1;
+
             #[inline]
             fn upto(self, lim: Self) -> Iter<Self> {
                 assert!(self <= lim);
@@ -85,7 +94,7 @@ macro_rules! mk_impl {
 
             #[inline]
             fn exponent_bias() -> Self::Exponent {
-                (1 << ($expn_n - 1)) - 1
+                Self::EXP_BIAS
             }
 
             #[inline]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -104,6 +104,18 @@ pub trait Ieee754: Copy + PartialEq + PartialOrd + Send + Sync + fmt::Debug + fm
     /// A type large enough to store the significand of `Self`.
     type Significand;
 
+    /// Number of bits used for the significand of Self
+    const SIGNIF_SIZE: u8;
+    /// Number of bits used for the exponent of Self;
+    const EXP_SIZE: u8;
+    /// Value of exponent part for zero/subnormal numbers
+    const EXP_ZERO_SUBNORMAL: Self::RawExponent;
+    /// Value of exponent part for inf/NaN numbers
+    const EXP_INF_NAN: Self::RawExponent;
+    const EXP_SMALLEST_NORMAL: Self::RawExponent;
+    const EXP_HIGHEST_NORMAL: Self::RawExponent;
+    const EXP_BIAS: Self::Exponent;
+
     /// Return the next value after `self`.
     ///
     /// Calling this on NaN or positive infinity will yield nonsense.


### PR DESCRIPTION
This PR aims to add a few consts on the trait, allowing any crate to directly access exponent/mantissa information on the type.

My main use so far has been in trying to expand your `fast-math` crate to handle both `f32` and `f64`. In many cases, the bit-tricks from `f32` are usable as-is for `f64` if we have access to these constants, which means that we can have a common implementation for `f32` and `f64`.

You may not want these here, in which case these can also exist as a separate trait somewhere else (my current fast-math changes add a `Ieee754Consts` trait with just these constants, but it feels... wrong and dirty).

I am more than happy to discuss, or would perfectly understand if you feel like this is the wrong place for these/they aren't needed.